### PR TITLE
Use github pre-release branch instead of npm version for defra-identity-hapi-plugin

### DIFF
--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
   "author": "Chris Cheshire",
   "license": "ISC",
   "dependencies": {
-    "@envage/defra-identity-hapi-plugin": "5.x.x",
+    "@envage/defra-identity-hapi-plugin": "git+https://github.com/DEFRA/defra-identity-hapi-plugin.git#pre-release",
     "@hapi/hapi": "^19.1.1",
     "@hapi/inert": "^6.0.1",
     "@hapi/vision": "^6.0.0",


### PR DESCRIPTION
Use github pre-release branch instead of npm version for defra-identity-hapi-plugin